### PR TITLE
Split free and paid forms to separate specialties

### DIFF
--- a/scripts/TestUEADB.sh
+++ b/scripts/TestUEADB.sh
@@ -131,7 +131,7 @@ else
     exit 1
 fi
 
-echo "<specialty name=\"SomeSpecialty\" maxEnrolleesInFreeForm=\"50\" maxEnrolleesInPaidForm=\"50\" isPedagogical=\"false\"></specialty>" > CorrectSpecialty.xml
+echo "<specialty name=\"SomeSpecialty\" maxEnrollees=\"50\" isPedagogical=\"false\"></specialty>" > CorrectSpecialty.xml
 thirdTestAddRemoveSpecialty="${UEADB} NewFaculty SomeFaculty , AddSpecialty SomeFaculty CorrectSpecialty.xml , RemoveSpecialty SomeFaculty SomeSpecialty"
 echo "Test: ${thirdTestAddRemoveSpecialty}"
 

--- a/sources/Tests/TestEnrollee/TestEnrollee.cpp
+++ b/sources/Tests/TestEnrollee/TestEnrollee.cpp
@@ -52,7 +52,7 @@ int main ()
 
     for (unsigned faculty = 0; faculty <= 3; faculty++)
     {
-        UEAA::EnrolleeChoice *choice = new UEAA::EnrolleeChoice (faculty, 1, UEAA::STUDY_FORM_FREE);
+        UEAA::EnrolleeChoice *choice = new UEAA::EnrolleeChoice (faculty, 1);
         std::cout << "Added faculty choice: " << choice->GetFaculty () << std::endl;
         enrollee->AddChoiceToBack (choice);
     }

--- a/sources/Tests/TestSpecialty/TestSpecialty.cpp
+++ b/sources/Tests/TestSpecialty/TestSpecialty.cpp
@@ -13,13 +13,11 @@ const unsigned PHYSICS_EXAM = UEAA::CStringToHash ("Physics");
 const unsigned LANGUAGE_EXAM = UEAA::CStringToHash ("Language");
 const unsigned SPECIALTY_ID = 1;
 
-const unsigned GENERATE_FOR_FREE_FORM = 15;
-const unsigned GENERATE_FOR_PAID_FORM = 10;
-const unsigned MAX_IN_FREE_FORM = 10;
-const unsigned MAX_IN_PAID_FORM = 5;
+const unsigned GENERATE_ENROLLEES = 15;
+const unsigned MAX_ENROLLEES = 10;
 
 void InitSpecialty (UEAA::Specialty *specialty);
-UEAA::Enrollee *GenerateEnrollee (UEAA::StudyForm studyForm);
+UEAA::Enrollee *GenerateEnrollee ();
 void PrintEnrollee (const UEAA::Enrollee *enrollee);
 void PrintEnrolleesList (const std::list <UEAA::Enrollee *> &enrollees);
 
@@ -31,23 +29,10 @@ int main ()
     UEAA::SharedPointer <UEAA::Specialty> specialty (new UEAA::Specialty (0, SPECIALTY_ID));
     InitSpecialty (specialty);
 
-    std::cout << "GENERATED ENROLLEES FOR FREE FORM:" << std::endl;
-    for (unsigned index = 0; index < GENERATE_FOR_FREE_FORM; index++)
+    std::cout << "GENERATED ENROLLEES:" << std::endl;
+    for (unsigned index = 0; index < GENERATE_ENROLLEES; index++)
     {
-        UEAA::SharedPointer <UEAA::Enrollee> enrollee = GenerateEnrollee (UEAA::STUDY_FORM_FREE);
-        PrintEnrollee (enrollee);
-        enrolleesBuffer.push_back (enrollee);
-        if (!specialty->AddEnrollee (enrollee))
-        {
-            std::cout << "Can't add enrollee!";
-            return 1;
-        }
-    }
-
-    std::cout << "GENERATED ENROLLEES FOR PAID FORM:" << std::endl;
-    for (unsigned index = 0; index < GENERATE_FOR_PAID_FORM; index++)
-    {
-        UEAA::SharedPointer <UEAA::Enrollee> enrollee = GenerateEnrollee (UEAA::STUDY_FORM_PAID);
+        UEAA::SharedPointer <UEAA::Enrollee> enrollee = GenerateEnrollee ();
         PrintEnrollee (enrollee);
         enrolleesBuffer.push_back (enrollee);
         if (!specialty->AddEnrollee (enrollee))
@@ -58,50 +43,30 @@ int main ()
     }
 
     std::cout << std::endl;
-    std::cout << "Choose free form: " << specialty->GetEnrolleesInFreeForm ().size () << std::endl;
-    std::cout << "Choose paid form: " << specialty->GetEnrolleesInPaidForm ().size () << std::endl;
-
-    if (specialty->GetEnrolleesInFreeForm ().size () != GENERATE_FOR_FREE_FORM)
+    std::cout << "Choose: " << specialty->GetEnrollees ().size () << std::endl;
+    if (specialty->GetEnrollees ().size () != GENERATE_ENROLLEES)
     {
         std::cout << "Incorrect enrollees count in free form (before removing)!" << std::endl;
         return 1;
     }
 
-    if (specialty->GetEnrolleesInPaidForm ().size () != GENERATE_FOR_PAID_FORM)
-    {
-        std::cout << "Incorrect enrollees count in paid form (before removing)!" << std::endl;
-        return 1;
-    }
-
     std::cout << "Removing excess enrollees..." << std::endl;
     std::list <UEAA::Enrollee *> excessEnrollees = specialty->RemoveExcessEnrollees ();
-    std::cout << "In free form: " << specialty->GetEnrolleesInFreeForm ().size () << std::endl;
-    std::cout << "In paid form: " << specialty->GetEnrolleesInPaidForm ().size () << std::endl;
+    std::cout << "After removing: " << specialty->GetEnrollees ().size () << std::endl;
 
-    if (specialty->GetEnrolleesInFreeForm ().size () != MAX_IN_FREE_FORM)
+    if (specialty->GetEnrollees ().size () != MAX_ENROLLEES)
     {
         std::cout << "Incorrect enrollees count in free form (after removing)!" << std::endl;
         return 1;
     }
 
-    if (specialty->GetEnrolleesInPaidForm ().size () != MAX_IN_PAID_FORM)
-    {
-        std::cout << "Incorrect enrollees count in paid form (after removing)!" << std::endl;
-        return 1;
-    }
-
-    std::cout << "ENROLLEES IN FREE FORM:" << std::endl;
-    PrintEnrolleesList (specialty->GetEnrolleesInFreeForm ());
-
-    std::cout << "ENROLLEES IN PAID FORM:" << std::endl;
-    PrintEnrolleesList (specialty->GetEnrolleesInPaidForm ());
+    std::cout << "ENROLLEES IN SPECIALTY:" << std::endl;
+    PrintEnrolleesList (specialty->GetEnrollees ());
 
     for (auto iterator = excessEnrollees.cbegin (); iterator != excessEnrollees.cend (); iterator++)
     {
         const UEAA::Enrollee *excessEnrollee = *iterator;
-        const std::list <UEAA::Enrollee *> anotherEnrollees =
-                (excessEnrollee->GetCurrentChoice ()->GetStudyForm () == UEAA::STUDY_FORM_FREE) ?
-                    specialty->GetEnrolleesInFreeForm () : specialty->GetEnrolleesInPaidForm ();
+        const std::list <UEAA::Enrollee *> anotherEnrollees = specialty->GetEnrollees ();
 
         for (auto anotherEnrolleesIterator = anotherEnrollees.cbegin ();
              anotherEnrolleesIterator != anotherEnrollees.cend (); anotherEnrolleesIterator++)
@@ -123,9 +88,7 @@ int main ()
 
 void InitSpecialty (UEAA::Specialty *specialty)
 {
-    specialty->SetMaxEnrolleesInFreeForm (MAX_IN_FREE_FORM);
-    specialty->SetMaxEnrolleesInPaidForm (MAX_IN_PAID_FORM);
-
+    specialty->SetMaxEnrollees (MAX_ENROLLEES);
     {
         std::vector <std::pair <bool, std::vector <unsigned> > > exams;
         exams.push_back (std::pair <bool, std::vector <unsigned> > (true, {MATH_EXAM}));
@@ -142,7 +105,7 @@ void InitSpecialty (UEAA::Specialty *specialty)
     }
 }
 
-UEAA::Enrollee *GenerateEnrollee (UEAA::StudyForm studyForm)
+UEAA::Enrollee *GenerateEnrollee ()
 {
     UEAA::Enrollee *enrollee = new UEAA::Enrollee (UEAA::CStringToHash ("XX0000000"));
     enrollee->SetCertificateMark (MATH_EXAM, 5 + rand () % 6);
@@ -154,7 +117,7 @@ UEAA::Enrollee *GenerateEnrollee (UEAA::StudyForm studyForm)
     enrollee->SetExamResult (PHYSICS_EXAM, 30 + rand () % 71);
     enrollee->SetExamResult (LANGUAGE_EXAM, 30 + rand () % 71);
 
-    enrollee->AddChoiceToBack (new UEAA::EnrolleeChoice (0, SPECIALTY_ID, studyForm));
+    enrollee->AddChoiceToBack (new UEAA::EnrolleeChoice (0, SPECIALTY_ID));
     return enrollee;
 }
 

--- a/sources/Tests/TestUniversity/TestUniversity.cpp
+++ b/sources/Tests/TestUniversity/TestUniversity.cpp
@@ -65,7 +65,7 @@ int main ()
                 UEAA::Specialty *specialty = faculty->GetSpecialty (choice->GetSpecialty ());
                 if (specialty)
                 {
-                    const std::list <UEAA::Enrollee *> &anotherEnrollees = specialty->GetEnrolleesInFreeForm ();
+                    const std::list <UEAA::Enrollee *> &anotherEnrollees = specialty->GetEnrollees ();
                     for (auto anotherEnrolleeIterator = anotherEnrollees.cbegin ();
                          anotherEnrolleeIterator != anotherEnrollees.cend (); anotherEnrolleeIterator++)
                     {
@@ -122,17 +122,17 @@ UEAA::Enrollee *GenerateEnrollee (bool addTech, bool addArts, UEAA::DeHashTable 
     if (addTech)
     {
         enrollee->AddChoiceToBack (new UEAA::EnrolleeChoice (
-                                       TECH_FACULTY, TechFaculty::APPLIED_COMPUTER_SCIENCE, UEAA::STUDY_FORM_FREE));
+                                       TECH_FACULTY, TechFaculty::APPLIED_COMPUTER_SCIENCE_FREE));
         enrollee->AddChoiceToBack (new UEAA::EnrolleeChoice (
-                                       TECH_FACULTY, TechFaculty::COMPUTER_SCIENCE, UEAA::STUDY_FORM_FREE));
+                                       TECH_FACULTY, TechFaculty::COMPUTER_SCIENCE_FREE));
     }
 
     if (addArts)
     {
         enrollee->AddChoiceToBack (new UEAA::EnrolleeChoice (
-                                       ARTS_FACULTY, ArtsFaculty::PAINTING, UEAA::STUDY_FORM_FREE));
+                                       ARTS_FACULTY, ArtsFaculty::PAINTING_FREE));
         enrollee->AddChoiceToBack (new UEAA::EnrolleeChoice (
-                                       ARTS_FACULTY, ArtsFaculty::THEATRE, UEAA::STUDY_FORM_FREE));
+                                       ARTS_FACULTY, ArtsFaculty::THEATRE_FREE));
     }
     enrolleesGeneratorCounter_++;
     return enrollee;
@@ -163,7 +163,7 @@ UEAA::Faculty *CreateTechFaculty (UEAA::University *university)
 {
     UEAA::Faculty *techFaculty = new UEAA::Faculty (university, TECH_FACULTY);
     UEAA::SharedPointer <UEAA::Specialty> acsSpecialty (
-                CreateTechSpecialty (techFaculty, TechFaculty::APPLIED_COMPUTER_SCIENCE, TechFaculty::ACS_MAX_ENROLLEES_IN_FREE_FORM));
+                CreateTechSpecialty (techFaculty, TechFaculty::APPLIED_COMPUTER_SCIENCE_FREE, TechFaculty::ACS_MAX_ENROLLEES_IN_FREE));
     if (!techFaculty->AddSpecialty (acsSpecialty))
     {
         std::cout << "Can't add ACS specialty!" << std::endl;
@@ -172,7 +172,7 @@ UEAA::Faculty *CreateTechFaculty (UEAA::University *university)
     }
 
     UEAA::SharedPointer <UEAA::Specialty> csSpecialty (
-                CreateTechSpecialty (techFaculty, TechFaculty::COMPUTER_SCIENCE, TechFaculty::CS_MAX_ENROLLEES_IN_FREE_FORM));
+                CreateTechSpecialty (techFaculty, TechFaculty::COMPUTER_SCIENCE_FREE, TechFaculty::CS_MAX_ENROLLEES_IN_FREE));
     if (!techFaculty->AddSpecialty (csSpecialty))
     {
         std::cout << "Can't add CS specialty!" << std::endl;
@@ -182,11 +182,10 @@ UEAA::Faculty *CreateTechFaculty (UEAA::University *university)
     return techFaculty;
 }
 
-UEAA::Specialty *CreateTechSpecialty (UEAA::Faculty *faculty, unsigned id, unsigned maxFreeEnrollees)
+UEAA::Specialty *CreateTechSpecialty (UEAA::Faculty *faculty, unsigned id, unsigned maxEnrollees)
 {
     UEAA::Specialty *specialty = new UEAA::Specialty (faculty, id);
-    specialty->SetMaxEnrolleesInFreeForm (maxFreeEnrollees);
-    specialty->SetMaxEnrolleesInPaidForm (0);
+    specialty->SetMaxEnrollees (maxEnrollees);
 
     {
         std::vector <std::pair <bool, std::vector <unsigned> > > exams;
@@ -209,7 +208,7 @@ UEAA::Faculty *CreateArtsFaculty (UEAA::University *university)
 {
     UEAA::Faculty *artsFaculty = new UEAA::Faculty (university, ARTS_FACULTY);
     UEAA::SharedPointer <UEAA::Specialty> paintingSpecialty (
-                CreateArtsSpecialty (artsFaculty, ArtsFaculty::PAINTING, ArtsFaculty::PAINTING_MAX_ENROLLEES_IN_FREE_FORM));
+                CreateArtsSpecialty (artsFaculty, ArtsFaculty::PAINTING_FREE, ArtsFaculty::PAINTING_MAX_ENROLLEES_IN_FREE));
     if (!artsFaculty->AddSpecialty (paintingSpecialty))
     {
         std::cout << "Can't add Painting specialty!" << std::endl;
@@ -218,7 +217,7 @@ UEAA::Faculty *CreateArtsFaculty (UEAA::University *university)
     }
 
     UEAA::SharedPointer <UEAA::Specialty> theatreSpecialty (
-                CreateArtsSpecialty (artsFaculty, ArtsFaculty::THEATRE, ArtsFaculty::THEATRE_MAX_ENROLLEES_IN_FREE_FORM));
+                CreateArtsSpecialty (artsFaculty, ArtsFaculty::THEATRE_FREE, ArtsFaculty::THEATRE_MAX_ENROLLEES_IN_FREE));
     if (!artsFaculty->AddSpecialty (theatreSpecialty))
     {
         std::cout << "Can't add Theatre specialty!" << std::endl;
@@ -228,11 +227,10 @@ UEAA::Faculty *CreateArtsFaculty (UEAA::University *university)
     return artsFaculty;
 }
 
-UEAA::Specialty *CreateArtsSpecialty (UEAA::Faculty *faculty, unsigned id, unsigned maxFreeEnrollees)
+UEAA::Specialty *CreateArtsSpecialty (UEAA::Faculty *faculty, unsigned id, unsigned maxEnrollees)
 {
     UEAA::Specialty *specialty = new UEAA::Specialty (faculty, id);
-    specialty->SetMaxEnrolleesInFreeForm (maxFreeEnrollees);
-    specialty->SetMaxEnrolleesInPaidForm (0);
+    specialty->SetMaxEnrollees (maxEnrollees);
 
     {
         std::vector <std::pair <bool, std::vector <unsigned> > > exams;

--- a/sources/Tests/TestUniversity/TestUniversity.hpp
+++ b/sources/Tests/TestUniversity/TestUniversity.hpp
@@ -19,21 +19,21 @@ const unsigned ARTS_INTERNAL_EXAM = UEAA::CStringToHash ("Arts");
 const unsigned TECH_FACULTY = UEAA::CStringToHash ("Tech");
 namespace TechFaculty
 {
-const unsigned APPLIED_COMPUTER_SCIENCE = UEAA::CStringToHash ("AppliedComputerScience");
-const unsigned COMPUTER_SCIENCE = UEAA::CStringToHash ("ComputerScience");
+const unsigned APPLIED_COMPUTER_SCIENCE_FREE = UEAA::CStringToHash ("AppliedComputerScience (Free)");
+const unsigned COMPUTER_SCIENCE_FREE = UEAA::CStringToHash ("ComputerScience (Free)");
 
-const unsigned ACS_MAX_ENROLLEES_IN_FREE_FORM = 25;
-const unsigned CS_MAX_ENROLLEES_IN_FREE_FORM = 100;
+const unsigned ACS_MAX_ENROLLEES_IN_FREE = 25;
+const unsigned CS_MAX_ENROLLEES_IN_FREE = 100;
 }
 
 const unsigned ARTS_FACULTY = UEAA::CStringToHash ("Arts");
 namespace ArtsFaculty
 {
-const unsigned PAINTING = UEAA::CStringToHash ("Painting");
-const unsigned THEATRE = UEAA::CStringToHash ("Theatre");
+const unsigned PAINTING_FREE = UEAA::CStringToHash ("Painting (Free)");
+const unsigned THEATRE_FREE = UEAA::CStringToHash ("Theatre (Free)");
 
-const unsigned PAINTING_MAX_ENROLLEES_IN_FREE_FORM = 50;
-const unsigned THEATRE_MAX_ENROLLEES_IN_FREE_FORM = 50;
+const unsigned PAINTING_MAX_ENROLLEES_IN_FREE = 50;
+const unsigned THEATRE_MAX_ENROLLEES_IN_FREE = 50;
 }
 
 const unsigned TECH_ENROLLEES = 125;
@@ -45,7 +45,7 @@ UEAA::Enrollee *GenerateEnrollee (bool addTech, bool addArts, UEAA::DeHashTable 
 
 UEAA::University *CreateTestUniversity ();
 UEAA::Faculty *CreateTechFaculty (UEAA::University *university);
-UEAA::Specialty *CreateTechSpecialty (UEAA::Faculty *faculty, unsigned id, unsigned maxFreeEnrollees);
+UEAA::Specialty *CreateTechSpecialty (UEAA::Faculty *faculty, unsigned id, unsigned maxEnrollees);
 UEAA::Faculty *CreateArtsFaculty (UEAA::University *university);
-UEAA::Specialty *CreateArtsSpecialty (UEAA::Faculty *faculty, unsigned id, unsigned maxFreeEnrollees);
+UEAA::Specialty *CreateArtsSpecialty (UEAA::Faculty *faculty, unsigned id, unsigned maxEnrollees);
 void PrintEnrollee (const UEAA::Enrollee *enrollee, UEAA::DeHashTable *deHashTable);

--- a/sources/Tests/TestXMLSerialization/TestXMLSerialization.cpp
+++ b/sources/Tests/TestXMLSerialization/TestXMLSerialization.cpp
@@ -63,12 +63,18 @@ void InitHashes (UEAA::DeHashTable *deHashTable)
     ARTS_INTERNAL_EXAM = UEAA::CStringToHash ("Arts Internal", deHashTable);
 
     TECH_FACULTY = UEAA::CStringToHash ("Tech Faculty", deHashTable);
-    TechFaculty::APPLIED_COMPUTER_SCIENCE = UEAA::CStringToHash ("Applied Computer Science", deHashTable);
-    TechFaculty::COMPUTER_SCIENCE = UEAA::CStringToHash ("Computer Science", deHashTable);
+    TechFaculty::APPLIED_COMPUTER_SCIENCE_FREE = UEAA::CStringToHash ("Applied Computer Science (Free)", deHashTable);
+    TechFaculty::COMPUTER_SCIENCE_FREE = UEAA::CStringToHash ("Computer Science (Free)", deHashTable);
+
+    TechFaculty::APPLIED_COMPUTER_SCIENCE_PAID = UEAA::CStringToHash ("Applied Computer Science (Paid)", deHashTable);
+    TechFaculty::COMPUTER_SCIENCE_PAID = UEAA::CStringToHash ("Computer Science (Paid)", deHashTable);
 
     ARTS_FACULTY = UEAA::CStringToHash ("Arts Faculty", deHashTable);
-    ArtsFaculty::PAINTING = UEAA::CStringToHash ("Painting", deHashTable);
-    ArtsFaculty::THEATRE = UEAA::CStringToHash ("Theatre", deHashTable);
+    ArtsFaculty::PAINTING_FREE = UEAA::CStringToHash ("Painting (Free)", deHashTable);
+    ArtsFaculty::THEATRE_FREE = UEAA::CStringToHash ("Theatre (Free)", deHashTable);
+
+    ArtsFaculty::PAINTING_PAID = UEAA::CStringToHash ("Painting (Paid)", deHashTable);
+    ArtsFaculty::THEATRE_PAID = UEAA::CStringToHash ("Theatre (Paid)", deHashTable);
 }
 
 UEAA::Enrollee *GenerateEnrollee (bool addTech, bool addArts, UEAA::DeHashTable *deHashTable)
@@ -102,28 +108,20 @@ UEAA::Enrollee *GenerateEnrollee (bool addTech, bool addArts, UEAA::DeHashTable 
 
     if (addTech)
     {
-        enrollee->AddChoiceToBack (new UEAA::EnrolleeChoice (
-                TECH_FACULTY, TechFaculty::APPLIED_COMPUTER_SCIENCE, UEAA::STUDY_FORM_FREE));
-        enrollee->AddChoiceToBack (new UEAA::EnrolleeChoice (
-                TECH_FACULTY, TechFaculty::COMPUTER_SCIENCE, UEAA::STUDY_FORM_FREE));
+        enrollee->AddChoiceToBack (new UEAA::EnrolleeChoice (TECH_FACULTY, TechFaculty::APPLIED_COMPUTER_SCIENCE_FREE));
+        enrollee->AddChoiceToBack (new UEAA::EnrolleeChoice (TECH_FACULTY, TechFaculty::COMPUTER_SCIENCE_FREE));
 
-        enrollee->AddChoiceToBack (new UEAA::EnrolleeChoice (
-                TECH_FACULTY, TechFaculty::APPLIED_COMPUTER_SCIENCE, UEAA::STUDY_FORM_PAID));
-        enrollee->AddChoiceToBack (new UEAA::EnrolleeChoice (
-                TECH_FACULTY, TechFaculty::COMPUTER_SCIENCE, UEAA::STUDY_FORM_PAID));
+        enrollee->AddChoiceToBack (new UEAA::EnrolleeChoice (TECH_FACULTY, TechFaculty::APPLIED_COMPUTER_SCIENCE_PAID));
+        enrollee->AddChoiceToBack (new UEAA::EnrolleeChoice (TECH_FACULTY, TechFaculty::COMPUTER_SCIENCE_PAID));
     }
 
     if (addArts)
     {
-        enrollee->AddChoiceToBack (new UEAA::EnrolleeChoice (
-                ARTS_FACULTY, ArtsFaculty::PAINTING, UEAA::STUDY_FORM_FREE));
-        enrollee->AddChoiceToBack (new UEAA::EnrolleeChoice (
-                ARTS_FACULTY, ArtsFaculty::THEATRE, UEAA::STUDY_FORM_FREE));
+        enrollee->AddChoiceToBack (new UEAA::EnrolleeChoice (ARTS_FACULTY, ArtsFaculty::PAINTING_FREE));
+        enrollee->AddChoiceToBack (new UEAA::EnrolleeChoice (ARTS_FACULTY, ArtsFaculty::THEATRE_FREE));
 
-        enrollee->AddChoiceToBack (new UEAA::EnrolleeChoice (
-                ARTS_FACULTY, ArtsFaculty::PAINTING, UEAA::STUDY_FORM_PAID));
-        enrollee->AddChoiceToBack (new UEAA::EnrolleeChoice (
-                ARTS_FACULTY, ArtsFaculty::THEATRE, UEAA::STUDY_FORM_PAID));
+        enrollee->AddChoiceToBack (new UEAA::EnrolleeChoice (ARTS_FACULTY, ArtsFaculty::PAINTING_PAID));
+        enrollee->AddChoiceToBack (new UEAA::EnrolleeChoice (ARTS_FACULTY, ArtsFaculty::THEATRE_PAID));
     }
     enrolleesGeneratorCounter_++;
     return enrollee;
@@ -153,35 +151,48 @@ UEAA::University *CreateTestUniversity ()
 UEAA::Faculty *CreateTechFaculty (UEAA::University *university)
 {
     UEAA::Faculty *techFaculty = new UEAA::Faculty (university, TECH_FACULTY);
-    UEAA::SharedPointer <UEAA::Specialty> acsSpecialty (
-            CreateTechSpecialty (techFaculty, TechFaculty::APPLIED_COMPUTER_SCIENCE,
-                                 TechFaculty::ACS_MAX_ENROLLEES_IN_FREE_FORM,
-                                 TechFaculty::ACS_MAX_ENROLLEES_IN_PAID_FORM));
-    if (!techFaculty->AddSpecialty (acsSpecialty))
+    UEAA::SharedPointer <UEAA::Specialty> acsFreeSpecialty (
+            CreateTechSpecialty (techFaculty, TechFaculty::APPLIED_COMPUTER_SCIENCE_FREE, TechFaculty::ACS_MAX_ENROLLEES_IN_FREE));
+    if (!techFaculty->AddSpecialty (acsFreeSpecialty))
     {
-        std::cout << "Can't add ACS specialty!" << std::endl;
+        std::cout << "Can't add ACS free specialty!" << std::endl;
         delete techFaculty;
-        return 0;
+        return nullptr;
     }
 
-    UEAA::SharedPointer <UEAA::Specialty> csSpecialty (
-            CreateTechSpecialty (techFaculty, TechFaculty::COMPUTER_SCIENCE,
-                                 TechFaculty::CS_MAX_ENROLLEES_IN_FREE_FORM,
-                                 TechFaculty::CS_MAX_ENROLLEES_IN_PAID_FORM));
-    if (!techFaculty->AddSpecialty (csSpecialty))
+    UEAA::SharedPointer <UEAA::Specialty> acsPaidSpecialty (
+            CreateTechSpecialty (techFaculty, TechFaculty::APPLIED_COMPUTER_SCIENCE_PAID, TechFaculty::ACS_MAX_ENROLLEES_IN_PAID));
+    if (!techFaculty->AddSpecialty (acsPaidSpecialty))
     {
-        std::cout << "Can't add CS specialty!" << std::endl;
+        std::cout << "Can't add ACS paid specialty!" << std::endl;
         delete techFaculty;
-        return 0;
+        return nullptr;
+    }
+
+    UEAA::SharedPointer <UEAA::Specialty> csFreeSpecialty (
+            CreateTechSpecialty (techFaculty, TechFaculty::COMPUTER_SCIENCE_FREE, TechFaculty::CS_MAX_ENROLLEES_IN_FREE));
+    if (!techFaculty->AddSpecialty (csFreeSpecialty))
+    {
+        std::cout << "Can't add CS free specialty!" << std::endl;
+        delete techFaculty;
+        return nullptr;
+    }
+
+    UEAA::SharedPointer <UEAA::Specialty> csPaidSpecialty (
+            CreateTechSpecialty (techFaculty, TechFaculty::COMPUTER_SCIENCE_PAID, TechFaculty::CS_MAX_ENROLLEES_IN_PAID));
+    if (!techFaculty->AddSpecialty (csPaidSpecialty))
+    {
+        std::cout << "Can't add CS paid specialty!" << std::endl;
+        delete techFaculty;
+        return nullptr;
     }
     return techFaculty;
 }
 
-UEAA::Specialty *CreateTechSpecialty (UEAA::Faculty *faculty, unsigned id, unsigned maxFreeEnrollees, unsigned maxPaidEnrollees)
+UEAA::Specialty *CreateTechSpecialty (UEAA::Faculty *faculty, unsigned id, unsigned maxEnrollees)
 {
     UEAA::Specialty *specialty = new UEAA::Specialty (faculty, id);
-    specialty->SetMaxEnrolleesInFreeForm (maxFreeEnrollees);
-    specialty->SetMaxEnrolleesInPaidForm (maxPaidEnrollees);
+    specialty->SetMaxEnrollees (maxEnrollees);
     specialty->AddAcceptedRODSubject (MATH_EXAM);
 
     {
@@ -204,37 +215,52 @@ UEAA::Specialty *CreateTechSpecialty (UEAA::Faculty *faculty, unsigned id, unsig
 UEAA::Faculty *CreateArtsFaculty (UEAA::University *university)
 {
     UEAA::Faculty *artsFaculty = new UEAA::Faculty (university, ARTS_FACULTY);
-    UEAA::SharedPointer <UEAA::Specialty> paintingSpecialty (
-            CreateArtsSpecialty (artsFaculty, ArtsFaculty::PAINTING,
-                                 ArtsFaculty::PAINTING_MAX_ENROLLEES_IN_FREE_FORM,
-                                 ArtsFaculty::PAINTING_MAX_ENROLLEES_IN_PAID_FORM));
+    UEAA::SharedPointer <UEAA::Specialty> paintingFreeSpecialty (
+            CreateArtsSpecialty (artsFaculty, ArtsFaculty::PAINTING_FREE, ArtsFaculty::PAINTING_MAX_ENROLLEES_IN_FREE));
 
-    if (!artsFaculty->AddSpecialty (paintingSpecialty))
+    if (!artsFaculty->AddSpecialty (paintingFreeSpecialty))
     {
-        std::cout << "Can't add Painting specialty!" << std::endl;
+        std::cout << "Can't add Painting free specialty!" << std::endl;
         delete artsFaculty;
-        return 0;
+        return nullptr;
     }
 
-    UEAA::SharedPointer <UEAA::Specialty> theatreSpecialty (
-            CreateArtsSpecialty (artsFaculty, ArtsFaculty::THEATRE,
-                                 ArtsFaculty::THEATRE_MAX_ENROLLEES_IN_FREE_FORM,
-                                 ArtsFaculty::THEATRE_MAX_ENROLLEES_IN_PAID_FORM));
+    UEAA::SharedPointer <UEAA::Specialty> paintingPaidSpecialty (
+            CreateArtsSpecialty (artsFaculty, ArtsFaculty::PAINTING_PAID, ArtsFaculty::PAINTING_MAX_ENROLLEES_IN_PAID));
 
-    if (!artsFaculty->AddSpecialty (theatreSpecialty))
+    if (!artsFaculty->AddSpecialty (paintingPaidSpecialty))
     {
-        std::cout << "Can't add Theatre specialty!" << std::endl;
+        std::cout << "Can't add Painting paid specialty!" << std::endl;
         delete artsFaculty;
-        return 0;
+        return nullptr;
+    }
+
+    UEAA::SharedPointer <UEAA::Specialty> theatreFreeSpecialty (
+            CreateArtsSpecialty (artsFaculty, ArtsFaculty::THEATRE_FREE, ArtsFaculty::THEATRE_MAX_ENROLLEES_IN_FREE));
+
+    if (!artsFaculty->AddSpecialty (theatreFreeSpecialty))
+    {
+        std::cout << "Can't add Theatre free specialty!" << std::endl;
+        delete artsFaculty;
+        return nullptr;
+    }
+
+    UEAA::SharedPointer <UEAA::Specialty> theatrePaidSpecialty (
+            CreateArtsSpecialty (artsFaculty, ArtsFaculty::THEATRE_PAID, ArtsFaculty::THEATRE_MAX_ENROLLEES_IN_PAID));
+
+    if (!artsFaculty->AddSpecialty (theatrePaidSpecialty))
+    {
+        std::cout << "Can't add Theatre paid specialty!" << std::endl;
+        delete artsFaculty;
+        return nullptr;
     }
     return artsFaculty;
 }
 
-UEAA::Specialty *CreateArtsSpecialty (UEAA::Faculty *faculty, unsigned id, unsigned maxFreeEnrollees, unsigned maxPaidEnrollees)
+UEAA::Specialty *CreateArtsSpecialty (UEAA::Faculty *faculty, unsigned id, unsigned maxEnrollees)
 {
     UEAA::Specialty *specialty = new UEAA::Specialty (faculty, id);
-    specialty->SetMaxEnrolleesInFreeForm (maxFreeEnrollees);
-    specialty->SetMaxEnrolleesInPaidForm (maxPaidEnrollees);
+    specialty->SetMaxEnrollees (maxEnrollees);
     specialty->AddAcceptedRODSubject (SOCIETY_EXAM);
     specialty->SetIsPedagogical (true);
 

--- a/sources/Tests/TestXMLSerialization/TestXMLSerialization.hpp
+++ b/sources/Tests/TestXMLSerialization/TestXMLSerialization.hpp
@@ -19,27 +19,33 @@ unsigned ARTS_INTERNAL_EXAM = 0;
 unsigned TECH_FACULTY = 0;
 namespace TechFaculty
 {
-unsigned APPLIED_COMPUTER_SCIENCE = 0;
-unsigned COMPUTER_SCIENCE = 0;
+unsigned APPLIED_COMPUTER_SCIENCE_FREE = 0;
+unsigned COMPUTER_SCIENCE_FREE = 0;
 
-unsigned ACS_MAX_ENROLLEES_IN_FREE_FORM = 25;
-unsigned ACS_MAX_ENROLLEES_IN_PAID_FORM = 15;
+unsigned APPLIED_COMPUTER_SCIENCE_PAID = 0;
+unsigned COMPUTER_SCIENCE_PAID = 0;
 
-unsigned CS_MAX_ENROLLEES_IN_FREE_FORM = 100;
-unsigned CS_MAX_ENROLLEES_IN_PAID_FORM = 10;
+unsigned ACS_MAX_ENROLLEES_IN_FREE = 25;
+unsigned ACS_MAX_ENROLLEES_IN_PAID = 15;
+
+unsigned CS_MAX_ENROLLEES_IN_FREE = 100;
+unsigned CS_MAX_ENROLLEES_IN_PAID = 10;
 }
 
 unsigned ARTS_FACULTY = 0;
 namespace ArtsFaculty
 {
-unsigned PAINTING = 0;
-unsigned THEATRE = 0;
+unsigned PAINTING_FREE = 0;
+unsigned THEATRE_FREE = 0;
 
-unsigned PAINTING_MAX_ENROLLEES_IN_FREE_FORM = 50;
-unsigned PAINTING_MAX_ENROLLEES_IN_PAID_FORM = 100;
+unsigned PAINTING_PAID = 0;
+unsigned THEATRE_PAID = 0;
 
-unsigned THEATRE_MAX_ENROLLEES_IN_FREE_FORM = 50;
-unsigned THEATRE_MAX_ENROLLEES_IN_PAID_FORM = 100;
+unsigned PAINTING_MAX_ENROLLEES_IN_FREE = 50;
+unsigned PAINTING_MAX_ENROLLEES_IN_PAID = 100;
+
+unsigned THEATRE_MAX_ENROLLEES_IN_FREE = 50;
+unsigned THEATRE_MAX_ENROLLEES_IN_PAID = 100;
 }
 
 unsigned TECH_ENROLLEES = 100;
@@ -52,7 +58,7 @@ UEAA::Enrollee *GenerateEnrollee (bool addTech, bool addArts, UEAA::DeHashTable 
 
 UEAA::University *CreateTestUniversity ();
 UEAA::Faculty *CreateTechFaculty (UEAA::University *university);
-UEAA::Specialty *CreateTechSpecialty (UEAA::Faculty *faculty, unsigned id, unsigned maxFreeEnrollees, unsigned maxPaidEnrollees);
+UEAA::Specialty *CreateTechSpecialty (UEAA::Faculty *faculty, unsigned id, unsigned maxEnrollees);
 UEAA::Faculty *CreateArtsFaculty (UEAA::University *university);
-UEAA::Specialty *CreateArtsSpecialty (UEAA::Faculty *faculty, unsigned id, unsigned maxFreeEnrollees, unsigned maxPaidEnrollees);
+UEAA::Specialty *CreateArtsSpecialty (UEAA::Faculty *faculty, unsigned id, unsigned maxEnrollees);
 void PrintEnrollee (const UEAA::Enrollee *enrollee, const UEAA::DeHashTable *deHashTable);

--- a/sources/UEAA/Core/Enrollee/Enrollee.hpp
+++ b/sources/UEAA/Core/Enrollee/Enrollee.hpp
@@ -4,7 +4,6 @@
 #include <string>
 #include <vector>
 
-#include <UEAA/Core/Enrollee/StudyForm.hpp>
 #include <UEAA/Core/Enrollee/EnrolleeChoice.hpp>
 #include <UEAA/Core/Enrollee/RODType.hpp>
 #include <UEAA/Utils/XMLSerializable.hpp>

--- a/sources/UEAA/Core/Enrollee/EnrolleeChoice.cpp
+++ b/sources/UEAA/Core/Enrollee/EnrolleeChoice.cpp
@@ -6,16 +6,14 @@ namespace UEAA
 {
 EnrolleeChoice::EnrolleeChoice () :
     faculty_ (0),
-    specialty_ (0),
-    studyForm_ (STUDY_FORM_FREE)
+    specialty_ (0)
 {
 
 }
 
-EnrolleeChoice::EnrolleeChoice (unsigned faculty, unsigned specialty, StudyForm studyForm) :
+EnrolleeChoice::EnrolleeChoice (unsigned faculty, unsigned specialty) :
     faculty_ (faculty),
-    specialty_ (specialty),
-    studyForm_ (studyForm)
+    specialty_ (specialty)
 {
 
 }
@@ -45,35 +43,22 @@ void EnrolleeChoice::SetSpecialty (unsigned specialty)
     specialty_ = specialty;
 }
 
-StudyForm EnrolleeChoice::GetStudyForm () const
-{
-    return studyForm_;
-}
-
-void EnrolleeChoice::SetStudyForm (StudyForm studyForm)
-{
-    studyForm_ = studyForm;
-}
-
 void EnrolleeChoice::SaveToXML (tinyxml2::XMLDocument &document, tinyxml2::XMLElement *output, DeHashTable *deHashTable) const
 {
     output->SetAttribute ("faculty", deHashTable->DeHash (faculty_).c_str ());
     output->SetAttribute ("specialty", deHashTable->DeHash (specialty_).c_str ());
-    output->SetAttribute ("studyForm", studyForm_);
 }
 
 void EnrolleeChoice::LoadFromXML (tinyxml2::XMLElement *input, DeHashTable *deHashTable)
 {
     faculty_ = CStringToHash (input->Attribute ("faculty"), deHashTable);
     specialty_ = CStringToHash (input->Attribute ("specialty"), deHashTable);
-    studyForm_ = static_cast <StudyForm> (atoi (input->Attribute ("studyForm")));
 }
 
 bool EnrolleeChoice::operator == (const EnrolleeChoice &rhs) const
 {
     return faculty_ == rhs.faculty_ &&
-           specialty_ == rhs.specialty_ &&
-           studyForm_ == rhs.studyForm_;
+           specialty_ == rhs.specialty_;
 }
 
 bool EnrolleeChoice::operator != (const EnrolleeChoice &rhs) const

--- a/sources/UEAA/Core/Enrollee/EnrolleeChoice.hpp
+++ b/sources/UEAA/Core/Enrollee/EnrolleeChoice.hpp
@@ -1,5 +1,4 @@
 #pragma once
-#include <UEAA/Core/Enrollee/StudyForm.hpp>
 #include <UEAA/Utils/DeHashTable.hpp>
 #include <UEAA/Utils/XMLSerializable.hpp>
 #include <Dependencies/TinyXML2/tinyxml2.h>
@@ -10,7 +9,7 @@ class EnrolleeChoice : public XMLSerializable
 {
 public:
     EnrolleeChoice ();
-    EnrolleeChoice (unsigned faculty, unsigned specialty, StudyForm studyForm);
+    EnrolleeChoice (unsigned faculty, unsigned specialty);
     virtual ~EnrolleeChoice ();
 
     unsigned int GetFaculty () const;
@@ -18,9 +17,6 @@ public:
 
     unsigned int GetSpecialty () const;
     void SetSpecialty (unsigned specialty);
-
-    StudyForm GetStudyForm () const;
-    void SetStudyForm (StudyForm studyForm);
 
     virtual void SaveToXML (tinyxml2::XMLDocument &document, tinyxml2::XMLElement *output, DeHashTable *deHashTable) const;
     virtual void LoadFromXML (tinyxml2::XMLElement *input, DeHashTable *deHashTable);
@@ -31,6 +27,5 @@ public:
 private:
     unsigned faculty_;
     unsigned specialty_;
-    StudyForm studyForm_;
 };
 }

--- a/sources/UEAA/Core/Enrollee/StudyForm.hpp
+++ b/sources/UEAA/Core/Enrollee/StudyForm.hpp
@@ -1,9 +1,0 @@
-#pragma once
-namespace UEAA
-{
-enum StudyForm
-{
-    STUDY_FORM_FREE = 0,
-    STUDY_FORM_PAID = 1
-};
-}

--- a/sources/UEAA/Core/University/Specialty.hpp
+++ b/sources/UEAA/Core/University/Specialty.hpp
@@ -2,8 +2,6 @@
 #include <vector>
 #include <list>
 #include <string>
-
-#include <UEAA/Core/Enrollee/StudyForm.hpp>
 #include <UEAA/Utils/XMLSerializable.hpp>
 
 namespace UEAA
@@ -26,17 +24,13 @@ public:
     const std::vector <unsigned> &GetMarksInCertificatePriority () const;
     void SetMarksInCertificatePriority (const std::vector <unsigned> &marksInCertificatePriority);
 
-    const std::list <Enrollee *> & GetEnrolleesInFreeForm () const;
-    const std::list <Enrollee *> & GetEnrolleesInPaidForm () const;
     bool AddEnrollee (Enrollee *enrollee);
     std::list <Enrollee *> RemoveExcessEnrollees ();
     void ClearEnrollees ();
 
-    unsigned GetMaxEnrolleesInFreeForm () const;
-    void SetMaxEnrolleesInFreeForm (unsigned maxEnrolleesInFreeForm);
-
-    unsigned GetMaxEnrolleesInPaidForm () const;
-    void SetMaxEnrolleesInPaidForm (unsigned maxEnrolleesInPaidForm);
+    const std::list <Enrollee *> &GetEnrollees () const;
+    unsigned int GetMaxEnrollees () const;
+    void SetMaxEnrollees (unsigned int maxEnrollees);
 
     bool IsPedagogical () const;
     void SetIsPedagogical (bool isPedagogical);
@@ -54,10 +48,6 @@ public:
     bool operator != (const Specialty &rhs) const;
 
 private:
-    /// Returns false if there is no excess enrollees.
-    void RemoveExcessEnrolleesOfStudyForm (std::list <Enrollee *> &output, StudyForm studyForm);
-    void AddEnrolleeToOrder (Enrollee *enrollee, std::list <Enrollee *> &queue);
-
     Faculty *parent_;
     unsigned id_;
     /// List of required exams names hashes. Should be sorted by priority!
@@ -70,11 +60,8 @@ private:
     /// Priority for marks in certificate, used for comparing enrollees, which have same exams results.
     std::vector <unsigned> marksInCertificatePriority_;
 
-    std::list <Enrollee *> enrolleesInFreeForm_;
-    std::list <Enrollee *> enrolleesInPaidForm_;
-
-    unsigned maxEnrolleesInFreeForm_;
-    unsigned maxEnrolleesInPaidForm_;
+    std::list <Enrollee *> enrollees_;
+    unsigned maxEnrollees_;
 
     /// Enrollees with gold medal have priority in pedagogical specialties queues.
     bool isPedagogical_;


### PR DESCRIPTION
Now free and paid specialty forms must be created as separate specialties.
This mechanism can be also used to easily create part-time specialties (for example).